### PR TITLE
Feature/fix command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the installation instructions for this package.
 To make the CSV file containing sets of words and numbers, run:
 
 ```bash
-python setlexsem/generate/generate_data.py --config_path "configs/generation_data/numbers_and_words.yaml" --seed_value 292 --save_data 1
+python setlexsem/generate/generate_data.py --config-path "configs/generation_data/numbers_and_words.yaml" --seed-value 292 --save-data 
 ```
 
 ### Sample sets based on training-set frequency
@@ -78,7 +78,7 @@ To make the CSV file containing sets of words sampled by the approximated
 training-set frequency, run:
 
 ```bash
-python setlexsem/generate/generate_data.py --config_path "configs/generation_data/deciles.yaml" --seed_value 292 --save_data 1
+python setlexsem/generate/generate_data.py --config-path "configs/generation_data/deciles.yaml" --seed-value 292 --save-data
 ```
 
 ### Sample "deceptive" sets
@@ -91,7 +91,7 @@ python scripts/make_hyponyms.py --output-path data/hyponyms.json
 
 To make the CSV file containing deceptive sets:
 ```bash
-python setlexsem/generate/generate_data.py --config_path "configs/generation_data/deceptive.yaml" --seed_value 292 --save_data 1
+python setlexsem/generate/generate_data.py --config-path "configs/generation_data/deceptive.yaml" --seed-value 292 --save-data 
 ```
 
 ## Create the prompts
@@ -103,7 +103,7 @@ Once you've sampled the sets, create the prompts. The prompts are written as CSV
 To make the CSV file containing prompts sets of words and numbers, run:
 
 ```bash
-python setlexsem/generate/generate_prompts.py --config_path "configs/generation_prompt/test_config.yaml" --seed_value 292 --save_data 1
+python setlexsem/generate/generate_prompts.py --config-path "configs/generation_prompt/test_config.yaml" --seed-value 292 --save-data
 ```
 
 ## Run the evalution
@@ -112,7 +112,7 @@ python setlexsem/generate/generate_prompts.py --config_path "configs/generation_
 2. Run the prompts:
 
   ```bash
-  python setlexsem/experiment/run_experiments.py --account_number <account-number> --save_file 1 --load_last_run 1 --config_file configs/experiments/anthr_sonnet.yaml
+  python setlexsem/experiment/run_experiments.py --account-number ACCOUNT_NUMBER --save-file --load-previous-run --config-file configs/experiments/anthr_sonnet.yaml
   ```
 
   **Note:** Currently, our experiments are dependent on AWS Bedrock and need an AWS account number to be provided. However, you have the capability to run experiments using OPENAI_KEY. We will add more instructions soon.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This research repository maintains the code and the results for the research pap
 
 _"Set theory has become the standard foundation for mathematics, as every mathematical object can be viewed as a set."_ -[Stanford Encyclopedia of Philosophy](https://plato.stanford.edu/entries/set-theory/)
 
-## Install
+# Install
 
 When installing, it's important to upgrade to the most recent pip. This ensures that `setup.py` runs correctly. An outdated version of pip can fail to run the `InstallNltkWordnetAfterPackages` command class in setup.py and cause subsequent errors.
 
@@ -16,7 +16,7 @@ pip install -e .
 pip install -e ."[dev, test]"
 ```
 
-### NLTK words
+# NLTK words
 
 If you get errors from `nltk` about package `words` not being installed while
 executing the code in this repository, run:
@@ -29,7 +29,7 @@ nltk.download("words")
 Note that `words` should be automatically installed by `pip` when you follow
 the installation instructions for this package.
 
-## Directory structure
+# Project layout
 
 * `configs/`
   * `configs/experimetns` contains configuration files which specify hyperparamter settings for running experiments.
@@ -45,17 +45,19 @@ the installation instructions for this package.
   * `generate` contains code for generating data, sample synthetic sets, prompts and utils needed for data generation.
   * `prepare` contains helper functions for partitioning words according to their frequencies.
 
-## Generating datasets
+# Generate the dataset
 
-### Sample sets with numbers or words
+## Create the sets
 
-To sample your own data, you can run the following:
+### Sample sets of numbers or words
+
+To make the CSV file containing sets of words and numbers, run:
 
 ```bash
 python setlexsem/generate/generate_data.py --config_path "configs/generation_data/numbers_and_words.yaml" --seed_value 292 --save_data 1
 ```
 
-### Sample sets based on (approximated) training-set frequency
+### Sample sets based on training-set frequency
 
 To sample sets based on their training-set frequency, we use an approximation based on rank frequency in the Google Books Ngrams corpus.
 
@@ -72,7 +74,8 @@ scripts/make-deciles.sh
 
 This will take ~10 minutes or more, depending on your bandwidth and the speed of your computer.
 
-Then run the following to generate data.
+To make the CSV file containing sets of words sampled by the approximated
+training-set frequency, run:
 
 ```bash
 python setlexsem/generate/generate_data.py --config_path "configs/generation_data/deciles.yaml" --seed_value 292 --save_data 1
@@ -80,27 +83,33 @@ python setlexsem/generate/generate_data.py --config_path "configs/generation_dat
 
 ### Sample "deceptive" sets
 
-To sample "deceptive" sets (see paper for details), create `hyponyms.json` by
-running the following command:
+To sample semantically "deceptive" sets (see paper for details), create `hyponyms.json` by running the following command:
 
 ```bash
 python scripts/make_hyponyms.py --output-path data/hyponyms.json
 ```
 
-## Generating prompts
+To make the CSV file containing deceptive sets:
+```bash
+python setlexsem/generate/generate_data.py --config_path "configs/generation_data/deceptive.yaml" --seed_value 292 --save_data 1
+```
+
+## Create the prompts
+
+Once you've sampled the sets, create the prompts. The prompts are written as CSV files in the `prompts` directory.
 
 ### Example: Sets with numbers
 
-To generate your own data, you can run the following:
+To make the CSV file containing prompts sets of words and numbers, run:
 
 ```bash
 python setlexsem/generate/generate_prompts.py --config_path "configs/generation_prompt/test_config.yaml" --seed_value 292 --save_data 1
 ```
 
-## Running end-to-end evaluation
+## Run the evalution
 
 1. Create a config file like `configs/experiments/anthr_sonnet.yaml`
-2. Run the experiment:
+2. Run the prompts:
 
   ```bash
   python setlexsem/experiment/run_experiments.py --account_number <account-number> --save_file 1 --load_last_run 1 --config_file configs/experiments/anthr_sonnet.yaml
@@ -108,7 +117,7 @@ python setlexsem/generate/generate_prompts.py --config_path "configs/generation_
 
   **Note:** Currently, our experiments are dependent on AWS Bedrock and need an AWS account number to be provided. However, you have the capability to run experiments using OPENAI_KEY. We will add more instructions soon.
 
-3. Post-Processing results (Check whether your study_name is present in the STUDY2MODEL dict in setlexsem/constants.py)
+3. Post-process the results. (Check whether your `study_name` is present in the `STUDY2MODEL` dict in `setlexsem/constants.py`)
 
 ```bash
 python scripts/save_processed_results_for_study_list.py

--- a/configs/generation_data/deceptive.yaml
+++ b/configs/generation_data/deceptive.yaml
@@ -1,0 +1,15 @@
+set_types:
+  - deceptive_words
+n:
+  - 10000
+m:
+  - 2
+  - 4
+  - 8
+  - 16
+item_len:
+  - null
+overlap_fraction:
+  - null
+swap_status:
+  - false

--- a/setlexsem/experiment/run_experiments.py
+++ b/setlexsem/experiment/run_experiments.py
@@ -30,29 +30,32 @@ def replace_none(list_in):
 def parse_args():
     parser = argparse.ArgumentParser()
     # add account number
-    parser.add_argument("--account_number", type=str, help="account number")
     parser.add_argument(
-        "--config_file",
+        "--account-number",
+        type=str,
+        required=True,
+        help="AWS account number"
+    )
+    parser.add_argument(
+        "--config-file",
         type=str,
         default=os.path.join(PATH_ROOT, "config.yaml"),
-        help="save files to disk",
+        help="Path to experiment config file"
     )
     parser.add_argument(
-        "--save_files",
-        type=int,
-        help="save files to disk",
+        "--save-files",
+        action="store_true",
+        help="Save files to disk",
     )
     parser.add_argument(
-        "--load_last_run",
-        type=int,
-        default=1,
-        help="load last run",
+        "--load-previous-run",
+        action="store_true",
+        help="Load the previous run",
     )
     parser.add_argument(
-        "--debug_model_no_lm_call",
-        type=int,
-        default=0,
-        help="debug model without calling language model",
+        "--debug-model-no-lm-call",
+        action="store_true",
+        help="Debug model without calling language model",
     )
     args = parser.parse_args()
     return args

--- a/setlexsem/generate/generate_data.py
+++ b/setlexsem/generate/generate_data.py
@@ -19,24 +19,22 @@ from setlexsem.generate.utils_data_generation import (
 
 
 # define argparser
-def parse_args():
+def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--config_path",
+        "--config-path",
         type=str,
         required=True,
-        help="path to config file for data generation",
+        help="Path to config file for generating data",
     )
     parser.add_argument(
-        "--save_data",
-        type=int,
-        required=True,
-        help="save data to disk",
+        "--save-data",
+        action="store_true",
+        help="Save data to disk",
     )
-    parser.add_argument("--number_of_data_points", type=int, default=10000)
-    parser.add_argument("--seed_value", type=int, default=292)
-    args = parser.parse_args()
-    return args
+    parser.add_argument("--number-of-data-points", type=int, default=10000)
+    parser.add_argument("--seed-value", type=int, default=292)
+    return parser
 
 
 def read_data_gen_config(config_path="config.yaml"):
@@ -55,7 +53,8 @@ def read_data_gen_config(config_path="config.yaml"):
 
 if __name__ == "__main__":
     # parse args
-    args = parse_args()
+    parser = get_parser()
+    args = parser.parse_args()
     config_path = args.config_path
     save_data = args.save_data
     NUM_RUNS = args.number_of_data_points

--- a/setlexsem/generate/generate_prompts.py
+++ b/setlexsem/generate/generate_prompts.py
@@ -11,7 +11,7 @@ from itertools import product
 import pandas as pd
 from tqdm import tqdm
 
-from setlexsem.constants import PATH_PROMPTS_ROOT, PATH_ROOT
+from setlexsem.constants import PATH_PROMPTS_ROOT
 from setlexsem.generate.prompt import (
     PromptConfig,
     get_ground_truth,
@@ -34,15 +34,15 @@ def replace_none(list_in):
 
 
 # define argparser
-def parse_args():
+def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--config_path",
+        "--config-path",
         type=str,
-        help="save files to disk",
+        required=True,
+        help="Path to config file for generating prompts",
     )
-    args = parser.parse_args()
-    return args
+    return parser
 
 
 def create_prompt(
@@ -51,7 +51,6 @@ def create_prompt(
     num_runs=100,
     add_roles=False,  # Claude Instant
 ):
-    results = 0
     prompt_and_ground_truth = []
     for i in tqdm(range(num_runs)):
         # create two sets from the sampler
@@ -97,10 +96,8 @@ def main(config_file):
     config = read_config(config_file)
 
     # Experiment config
-    N_RUN = config["N_RUN"]
     RANDOM_SEED_VAL = config["RANDOM_SEED_VAL"]
     OP_LIST = config["OP_LIST"]
-    MODEL_NAME = config["MODEL_NAME"]
 
     # Sampler/Sets Config
     SET_TYPES = config["SET_TYPES"]
@@ -242,7 +239,8 @@ def main(config_file):
 # init
 if __name__ == "__main__":
     # parse args
-    args = parse_args()
+    parser = get_parser()
+    args = parser.parse_args()
     config_path = args.config_path
 
     main(config_path)


### PR DESCRIPTION
* Use dashes to separate names in command-line args.
* Use proper boolean command-line args.
* Update README.md after testing that commands run.