### PR TITLE
remove n from set generation, fix bug

### DIFF
--- a/setlexsem/generate/generate_sets.py
+++ b/setlexsem/generate/generate_sets.py
@@ -210,8 +210,14 @@ def get_sampler(hp: Dict[str, Any], random_state: random.Random) -> Sampler:
     set_type = hp["set_types"]
 
     if set_type == "numbers":
+        # override n if item-length is defined
+        if hp.get("item_len"):
+            n = None
+        else:
+            n = hp["n"]
+
         sampler = BasicNumberSampler(
-            n=hp["n"],
+            n=n,
             m_A=hp["m_A"],
             m_B=hp["m_B"],
             item_len=hp.get("item_len"),
@@ -219,7 +225,6 @@ def get_sampler(hp: Dict[str, Any], random_state: random.Random) -> Sampler:
         )
     elif set_type == "words":
         sampler = BasicWordSampler(
-            n=hp["n"],
             m_A=hp["m_A"],
             m_B=hp["m_B"],
             item_len=hp.get("item_len"),
@@ -227,7 +232,6 @@ def get_sampler(hp: Dict[str, Any], random_state: random.Random) -> Sampler:
         )
     elif "deciles" in set_type:
         sampler = DecileWordSampler(
-            n=hp["n"],
             m_A=hp["m_A"],
             m_B=hp["m_B"],
             item_len=hp.get("item_len"),
@@ -236,7 +240,6 @@ def get_sampler(hp: Dict[str, Any], random_state: random.Random) -> Sampler:
         )
     elif set_type == "deceptive_words":
         sampler = DeceptiveWordSampler(
-            n=hp["n"],
             m_A=hp["m_A"],
             m_B=hp["m_B"],
             random_state=random_state,
@@ -297,14 +300,16 @@ def make_sets(
                 sample_set=sampler, num_runs=number_of_data_points
             )
         except:
-            logger.warning(f"No data: {hp_set}")
+            logger.warning(
+                f"No data for: {hp_set} - Make sure hyperparameters can be used to generate a set."
+            )
             continue
 
-    # add hyperparameters and concatenate results
-    for ds in synthetic_sets:
-        temp_hp = hp_set.copy()
-        temp_hp.update(ds)
-        all_sets.append(temp_hp)
+        # add hyperparameters and concatenate results
+        for ds in synthetic_sets:
+            temp_hp = hp_set.copy()
+            temp_hp.update(ds)
+            all_sets.append(temp_hp)
 
     return all_sets
 

--- a/setlexsem/generate/sample.py
+++ b/setlexsem/generate/sample.py
@@ -344,15 +344,21 @@ class BasicNumberSampler(Sampler):
         super().__init__(
             m_A, m_B, item_len=item_len, random_state=random_state
         )
-        self.n = n
-        if m_A > n:
-            raise ValueError(
-                f"m ({m_A}) should be greater than n ({n}) but {m_A} <= {n}"
-            )
-        if m_B > n:
-            raise ValueError(
-                f"m ({m_B}) should be greater than n ({n}) but {m_B} <= {n}"
-            )
+        if self.item_len:
+            self.n = None
+        else:
+            self.n = n
+
+        if self.n is not None:
+            if m_A > n:
+                raise ValueError(
+                    f"m ({m_A}) should be greater than n ({n}) but {m_A} <= {n}"
+                )
+            if m_B > n:
+                raise ValueError(
+                    f"m ({m_B}) should be greater than n ({n}) but {m_B} <= {n}"
+                )
+
         self.init_range_filter()
 
     def init_range_filter(self):
@@ -400,11 +406,6 @@ class BasicNumberSampler(Sampler):
         str
             Filename string.
         """
-        if self.item_len:
-            n = None
-        else:
-            n = self.n
-
         return f"N-{n}_MA-{self.m_A}_MB-{self.m_B}_L-{self.item_len}"
 
     def to_dict(self):
@@ -441,7 +442,6 @@ class OverlapSampler(Sampler):
         overlap_fraction: int = None,
         overlap_n: int = None,
     ):
-
         super().__init__(
             sampler.m_A,
             sampler.m_B,

--- a/setlexsem/generate/sample.py
+++ b/setlexsem/generate/sample.py
@@ -344,10 +344,7 @@ class BasicNumberSampler(Sampler):
         super().__init__(
             m_A, m_B, item_len=item_len, random_state=random_state
         )
-        if self.item_len:
-            self.n = None
-        else:
-            self.n = n
+        self.n = None if self.item_len else n
 
         if self.n is not None:
             if m_A > n:

--- a/tests/generate/test_generate_sets.py
+++ b/tests/generate/test_generate_sets.py
@@ -66,21 +66,22 @@ def test_make_sets_from_sampler():
 def test_make_sets_generates_unique_sets():
     # Set up some sample hyperparameters
     hps = {
-        "set_types": ["numbers", "words"],
+        "set_types": ["numbers", "words", "decile_words"],
         "n": 1000,
-        "m_A": [2, 4],
-        "m_B": [2, 4],
+        "m_A": [2, 4, 8],
+        "m_B": [2, 4, 8],
+        "item_len": [None, 3, 5],
     }
 
     # Generate sets using make_sets
-    sets = make_sets(**hps, number_of_data_points=100, seed_value=42)
-
-    # Check that all sets are unique
-    set_tuples = [f"{(s['A'], s['B'])}" for s in sets]
-
-    assert len(set_tuples) == len(
-        set(set_tuples)
-    ), f"Found duplicates: {set_tuples}"
+    sets = make_sets(**hps, number_of_data_points=1000, seed_value=42)
+    pairs = set()
+    for d in sets:
+        a = tuple(sorted(d["A"]))
+        b = tuple(sorted(d["B"]))
+        pair = (a, b)
+        assert pair not in pairs, f"Duplicate pair found: A={a}, B={b}"
+        pairs.add(pair)
 
 
 # Test case 2: Ensure correct set lengths are generated

--- a/tests/generate/test_generate_sets.py
+++ b/tests/generate/test_generate_sets.py
@@ -2,7 +2,6 @@ import ast
 from typing import Any, Dict, Iterable, List, Tuple, Union
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
 
 from setlexsem.generate.generate_sets import (
@@ -67,22 +66,21 @@ def test_make_sets_from_sampler():
 def test_make_sets_generates_unique_sets():
     # Set up some sample hyperparameters
     hps = {
-        "set_types": ["numbers"],
-        "n": 20,
-        "m_A": 5,
-        "m_B": 5,
+        "set_types": ["numbers", "words"],
+        "n": 1000,
+        "m_A": [2, 4],
+        "m_B": [2, 4],
     }
 
     # Generate sets using make_sets
-    sets = make_sets(**hps, number_of_data_points=10, seed_value=42)
+    sets = make_sets(**hps, number_of_data_points=100, seed_value=42)
 
     # Check that all sets are unique
-    n_duplicated_A = pd.DataFrame(sets)["A"].duplicated().sum()
-    n_duplicated_B = pd.DataFrame(sets)["B"].duplicated().sum()
+    set_tuples = [f"{(s['A'], s['B'])}" for s in sets]
 
-    assert (
-        n_duplicated_A == 0 | n_duplicated_B == 0
-    ), f"{n_duplicated_A} duplicates were found in set A & {n_duplicated_B} duplicates were found in set B"
+    assert len(set_tuples) == len(
+        set(set_tuples)
+    ), f"Found duplicates: {set_tuples}"
 
 
 # Test case 2: Ensure correct set lengths are generated

--- a/tests/generate/test_generate_sets.py
+++ b/tests/generate/test_generate_sets.py
@@ -2,10 +2,12 @@ import ast
 from typing import Any, Dict, Iterable, List, Tuple, Union
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
 from setlexsem.generate.generate_sets import (
     generate_set_pair,
+    make_sets,
     make_sets_from_sampler,
     parse_set_pair,
 )
@@ -59,3 +61,65 @@ def test_make_sets_from_sampler():
     # Test with non-positive number of runs
     result = make_sets_from_sampler(mock_sampler, num_runs=0)
     assert result == []
+
+
+# Test case 1: Ensure unique sets are generated
+def test_make_sets_generates_unique_sets():
+    # Set up some sample hyperparameters
+    hps = {
+        "set_types": ["numbers"],
+        "n": 20,
+        "m_A": 5,
+        "m_B": 5,
+    }
+
+    # Generate sets using make_sets
+    sets = make_sets(**hps, number_of_data_points=10, seed_value=42)
+
+    # Check that all sets are unique
+    n_duplicated_A = pd.DataFrame(sets)["A"].duplicated().sum()
+    n_duplicated_B = pd.DataFrame(sets)["B"].duplicated().sum()
+
+    assert (
+        n_duplicated_A == 0 | n_duplicated_B == 0
+    ), f"{n_duplicated_A} duplicates were found in set A & {n_duplicated_B} duplicates were found in set B"
+
+
+# Test case 2: Ensure correct set lengths are generated
+def test_make_sets_set_lengths():
+    # Set up some sample hyperparameters
+    hps = {
+        "set_types": ["words"],
+        "n": 1000,
+        "m_A": 5,
+        "m_B": 7,
+    }
+
+    # Generate sets using make_sets
+    sets = make_sets(**hps, number_of_data_points=20, seed_value=42)
+
+    # Check that all sets have correct lengths
+    for s in sets:
+        assert len(s["A"]) == hps["m_A"]
+        assert len(s["B"]) == hps["m_B"]
+
+
+# Test case 3: Ensure overlap fraction is correctly applied
+def test_make_sets_overlap_fraction():
+    # Set up some sample hyperparameters
+    hps = {
+        "set_types": ["numbers"],
+        "n": 1000,
+        "m_A": 2,
+        "m_B": 2,
+        "overlap_fraction": 0.5,
+    }
+
+    # Generate sets using make_sets
+    sets = make_sets(**hps, number_of_data_points=10, seed_value=42)
+
+    # Check that overlap fraction is correctly applied
+    for s in sets:
+        overlap = len(s["A"].intersection(s["B"]))
+        expected_overlap = int(hps["overlap_fraction"] * hps["m_A"])
+        assert overlap == expected_overlap


### PR DESCRIPTION
When we removed 'n' we had some dependency in the set generation for other samplers. Removed those issues. Fix the bug when data was empty and added more detail for the error we were surfacing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
